### PR TITLE
📦️ Import `joblib` directly

### DIFF
--- a/PyPEER/create_peer.py
+++ b/PyPEER/create_peer.py
@@ -15,7 +15,6 @@ import numpy as np
 import pandas as pd
 import nibabel as nib
 from sklearn.svm import SVR
-from sklearn.externals import joblib
 
 from peer_func import *
 

--- a/PyPEER/estimate_eyemove.py
+++ b/PyPEER/estimate_eyemove.py
@@ -15,7 +15,6 @@ import numpy as np
 import pandas as pd
 import nibabel as nib
 from sklearn.svm import SVR
-from sklearn.externals import joblib
 
 from peer_func import *
 

--- a/PyPEER/peer_func.py
+++ b/PyPEER/peer_func.py
@@ -11,11 +11,11 @@ import os
 import sys
 import csv
 import json
+import joblib
 import numpy as np
 import pandas as pd
 import nibabel as nib
 from sklearn.svm import SVR
-from sklearn.externals import joblib
 
 
 def scaffolding():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+joblib
 numpy
 pandas
 nibabel

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='PyPEER',
-      version='1.0',
+      version='1.1',
       description='Predictive Eye Estimation Regression',
       url='https://github.com/ChildMindInstitute/PyPEER',
       author='Jake Son',


### PR DESCRIPTION
`sklearn.externals.joblib` [was deprecated in 0.20.1](https://scikit-learn.org/stable/whats_new/v0.20.html#miscellaneous) and [removed in 0.23.0](https://github.com/scikit-learn/scikit-learn/commit/c2f5fe3e43f18f788dfad218abc6498a3fbbe20c) in favor of importing `joblib` directly